### PR TITLE
JTAND-6910 Maven publish plugin needs to have the repo defined explic…

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -72,6 +72,12 @@ dependencies {
 }
 
 publishing {
+    repositories {
+        maven {
+            url "https://artifactory.jamf.build/artifactory/libs-release/libs-release-local"
+        }
+    }
+
     publications {
         aar(MavenPublication) {
             groupId = packageName


### PR DESCRIPTION
…itly

It does not take the configuration from the init.gradle script. After the discussion with delta, as the publishing is done using the Jenkins job, the credentials are not required (from local address). Also it is recommended (in order to be consistent  with backend libs) to hardcode the artifactory url into the project rather than define it on the machine level (init.gradle way).